### PR TITLE
ERC721 support

### DIFF
--- a/ERC721.sol
+++ b/ERC721.sol
@@ -1,0 +1,11 @@
+pragma solidity >=0.5.0 <0.6.0;
+
+contract ERC721 {
+  event Transfer(address indexed _from, address indexed _to, uint256 indexed _tokenId);
+  event Approval(address indexed _owner, address indexed _approved, uint256 indexed _tokenId);
+
+  function balanceOf(address _owner) external view returns (uint256);
+  function ownerOf(uint256 _tokenId) external view returns (address);
+  function transferFrom(address _from, address _to, uint256 _tokenId) external payable;
+  function approve(address _approved, uint256 _tokenId) external payable;
+}

--- a/ZombieAttack.sol
+++ b/ZombieAttack.sol
@@ -12,7 +12,7 @@ contract ZombieAttack is ZombieHelper {
     return uint(keccak256(abi.encodePacked(now, msg.sender, randNonce))) % _modulus;
   }
 
-  function attack(uint _zombieId, uint _targetId) external ownerOf(_zombieId) {
+  function attack(uint _zombieId, uint _targetId) external onlyOwnerOf(_zombieId) {
     Zombie storage myZombie = zombies[_zombieId];
     Zombie storage enemyZombie = zombies[_targetId];
     uint rand = randMod(100);

--- a/ZombieFeeding.sol
+++ b/ZombieFeeding.sol
@@ -20,7 +20,7 @@ contract KittyInterface {
 contract ZombieFeeding is ZombieFactory {
     KittyInterface kittyContract;
 
-    modifier ownerOf(uint _zombieId) {
+    modifier onlyOwnerOf(uint _zombieId) {
         require(msg.sender == zombieToOwner[_zombieId]);
         _;
     }
@@ -37,7 +37,7 @@ contract ZombieFeeding is ZombieFactory {
         return (_zombie.readyTime <= now);
     }
 
-    function feedAndMultiply(uint _zombieId, uint _targetDna, string memory _species) internal ownerOf(_zombieId) {
+    function feedAndMultiply(uint _zombieId, uint _targetDna, string memory _species) internal onlyOwnerOf(_zombieId) {
       require(_isReady(myZombie));
       _targetDna = _targetDna % dnaModulus;
       uint newDna = (myZombie.dna + _targetDna) / 2;

--- a/ZombieHelper.sol
+++ b/ZombieHelper.sol
@@ -25,11 +25,11 @@ contract ZombieHelper is ZombieFeeding {
     zombies[_zombieId].level++;
   }
 
-  function changeName(uint _zombieId, string calldata _newName) external aboveLevel(2, _zombieId) ownerOf(_zombieId) {
+  function changeName(uint _zombieId, string calldata _newName) external aboveLevel(2, _zombieId) onlyOwnerOf(_zombieId) {
       zombies[_zombieId].name = _newName;
   }
 
-  function changeDna(uint _zombieId, uint _newDna) external aboveLevel(20, _zombieId) ownerOf(_zombieId) {
+  function changeDna(uint _zombieId, uint _newDna) external aboveLevel(20, _zombieId) onlyOwnerOf(_zombieId) {
       zombies[_zombieId].dna = _newDna;
   }
 

--- a/ZombieOwnership.sol
+++ b/ZombieOwnership.sol
@@ -1,0 +1,22 @@
+pragma solidity >=0.5.0 <0.6.0;
+
+import "./ZombieAttack.sol";
+import "./ERC721.sol";
+
+contract ZombieOwnership is ZombieAttack, ERC721 {
+    function balanceOf(address _owner) external view returns (uint256) {
+        return ownerZombieCount[_owner];
+    }
+
+    function ownerOf(uint256 _tokenId) external view returns (address) {
+        return zombieToOwner[_tokenId];
+    }
+
+    function transferFrom(address _from, address _to, uint256 _tokenId) external payable {
+
+    }
+
+    function approve(address _approved, uint256 _tokenId) external payable {
+
+    }
+}

--- a/ZombieOwnership.sol
+++ b/ZombieOwnership.sol
@@ -4,6 +4,9 @@ import "./ZombieAttack.sol";
 import "./ERC721.sol";
 
 contract ZombieOwnership is ZombieAttack, ERC721 {
+    
+    mapping (uint => address) zombieApprovals;
+
     function balanceOf(address _owner) external view returns (uint256) {
         return ownerZombieCount[_owner];
     }
@@ -12,11 +15,20 @@ contract ZombieOwnership is ZombieAttack, ERC721 {
         return zombieToOwner[_tokenId];
     }
 
-    function transferFrom(address _from, address _to, uint256 _tokenId) external payable {
-
+    function _transfer(address _from, address _to, uint256 _tokenId) private {
+        ownerZombieCount[_to]++;
+        ownerZombieCount[_from]--;
+        zombieToOwner[_tokenId] = _to;
+        emit Transfer(_from, _to, _tokenId);
     }
 
-    function approve(address _approved, uint256 _tokenId) external payable {
+    function transferFrom(address _from, address _to, uint256 _tokenId) external payable {
+        require (zombieToOwner[_tokenId] == msg.sender || zombieApprovals[_tokenId] == msg.sender);
+        _transfer(_from, _to, _tokenId);
+    }
 
+    function approve(address _approved, uint256 _tokenId) external payable onlyOwnerOf(_tokenId) {
+        zombieApprovals[_tokenId] = _approved;
+        emit Approval(msg.sender, _approved, _tokenId);
     }
 }


### PR DESCRIPTION
- Added ERC721.sol file, that contains the specification.
- Created ZombieOwnership.sol, to implement ERC721 standard.
- Changed ownerOf modifier from ZombieFeeding contract to onlyOwnerOf, and replaced everywhere, to avoid conflict with ERC721 spec.
- ZombieOwnership: added zombieApprovals mapping and _transfer function, and filled transferFrom and approve functions, to support ERC721 ownership transfers.